### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/internal-actionlint.yml
+++ b/.github/workflows/internal-actionlint.yml
@@ -1,4 +1,6 @@
 name: actionlint
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/umatare5/common/security/code-scanning/1](https://github.com/umatare5/common/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. Since the workflow only checks out code and runs a linter, it does not require any write permissions. The best practice is to set `contents: read` at the workflow root, which will apply to all jobs unless overridden. This change should be made near the top of the file, after the `name` and before `on`. No additional methods, imports, or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
